### PR TITLE
Preliminary proof generation support for Boogie reals

### DIFF
--- a/Source/Isabelle/Ast/InnerAst.cs
+++ b/Source/Isabelle/Ast/InnerAst.cs
@@ -397,6 +397,21 @@ namespace Isabelle.Ast
         }
     }
 
+    public class RealConst : Term
+    {
+        public RealConst(BigDec val)
+        {
+            Val = val;
+        }
+        
+        public BigDec Val { get; }
+
+        public override T Dispatch<T>(TermVisitor<T> visitor)
+        {
+            return visitor.VisitRealConst(this);
+        }
+    }
+
     public class StringConst : Term
     {
         public readonly string s;
@@ -517,6 +532,7 @@ namespace Isabelle.Ast
         Bool,
         Nat,
         Int,
+        Real,
         String
     }
 
@@ -542,6 +558,11 @@ namespace Isabelle.Ast
         public static PrimitiveType CreateIntType()
         {
             return new PrimitiveType(SimpleType.Int);
+        }
+        
+        public static PrimitiveType CreateRealType()
+        {
+            return new PrimitiveType(SimpleType.Real);
         }
 
         public static PrimitiveType CreateStringType()

--- a/Source/Isabelle/Ast/IsaVisitor.cs
+++ b/Source/Isabelle/Ast/IsaVisitor.cs
@@ -67,6 +67,8 @@ namespace Isabelle.Ast
         public abstract R VisitNatConst(NatConst t);
 
         public abstract R VisitIntConst(IntConst t);
+        
+        public abstract R VisitRealConst(RealConst t);
 
         public abstract R VisitStringConst(StringConst t);
     }

--- a/Source/Isabelle/IsaPrettyPrint/TermPrettyPrinter.cs
+++ b/Source/Isabelle/IsaPrettyPrint/TermPrettyPrinter.cs
@@ -39,7 +39,10 @@ namespace Isabelle.IsaPrettyPrint
 
         public override string VisitRealConst(RealConst t)
         {
-            return t.Val.ToString();
+            if (t.Val.IsNegative)
+                return $"-{t.Val.Abs.ToDecimalString()}";
+            
+            return t.Val.ToDecimalString();
         }
 
         public override string VisitStringConst(StringConst t)

--- a/Source/Isabelle/IsaPrettyPrint/TermPrettyPrinter.cs
+++ b/Source/Isabelle/IsaPrettyPrint/TermPrettyPrinter.cs
@@ -37,6 +37,11 @@ namespace Isabelle.IsaPrettyPrint
             return t.Val.ToString();
         }
 
+        public override string VisitRealConst(RealConst t)
+        {
+            return t.Val.ToString();
+        }
+
         public override string VisitStringConst(StringConst t)
         {
             return "''" + t.s + "''";

--- a/Source/Isabelle/IsaPrettyPrint/TypeIsaPrettyPrinter.cs
+++ b/Source/Isabelle/IsaPrettyPrint/TypeIsaPrettyPrinter.cs
@@ -39,6 +39,8 @@ namespace Isabelle.IsaPrettyPrint
                     return "nat";
                 case SimpleType.String:
                     return "string";
+                case SimpleType.Real:
+                    return "real";
                 default:
                     throw new NotImplementedException();
             }

--- a/Source/Isabelle/Util/IsaCommonTerms.cs
+++ b/Source/Isabelle/Util/IsaCommonTerms.cs
@@ -28,6 +28,7 @@ namespace Isabelle.Util
         public static TermIdent EmptySet => TermIdentFromName("{}");
 
         public static Term EmptyMap => TermIdentFromName("Map.empty");
+        public static Term RealOfInt => TermIdentFromName("real_of_int");
 
         public static Term Let(Identifier boundVar, TypeIsa boundVarType, Term termSubst, Term body)
         {

--- a/Source/ProofGeneration/BoogieIsaInterface/IsaBoogieTerm.cs
+++ b/Source/ProofGeneration/BoogieIsaInterface/IsaBoogieTerm.cs
@@ -18,8 +18,10 @@ namespace ProofGeneration
     {
         private static readonly TermIdent intVId = IsaCommonTerms.TermIdentFromName("IntV");
         private static readonly TermIdent boolVId = IsaCommonTerms.TermIdentFromName("BoolV");
+        private static readonly TermIdent realVId = IsaCommonTerms.TermIdentFromName("RealV");
         private static readonly TermIdent intLitId = IsaCommonTerms.TermIdentFromName("LInt");
         private static readonly TermIdent boolLitId = IsaCommonTerms.TermIdentFromName("LBool");
+        private static readonly TermIdent realLitId = IsaCommonTerms.TermIdentFromName("LReal");
 
         private static readonly TermIdent varId = IsaCommonTerms.TermIdentFromName("Var");
         private static readonly TermIdent bvarId = IsaCommonTerms.TermIdentFromName("BVar");
@@ -73,6 +75,7 @@ namespace ProofGeneration
 
         public static TermIdent ConvertValToBoolId { get; } = IsaCommonTerms.TermIdentFromName("convert_val_to_bool");
         public static TermIdent ConvertValToIntId { get; } = IsaCommonTerms.TermIdentFromName("convert_val_to_int");
+        public static TermIdent ConvertValToRealId { get; } = IsaCommonTerms.TermIdentFromName("convert_val_to_real");
 
         //TODO initialize all the default constructors, so that they only need to be allocated once (Val, Var, etc...)
 
@@ -115,6 +118,8 @@ namespace ProofGeneration
                 return BoolLiteral(node.asBool);
             if (node.Type.IsInt)
                 return IntLiteral(node.asBigNum);
+            if (node.Type.IsReal)
+                return RealLiteral(node.asBigDec);
             throw new NotImplementedException();
         }
 
@@ -158,6 +163,27 @@ namespace ProofGeneration
         public static Term BoolVal(Term b)
         {
             return new TermApp(boolVId, b);
+        }
+        
+        public static Term RealLiteral(BigDec dec)
+        {
+            return new TermApp(realLitId, new RealConst(dec));
+        }
+
+        public static Term RealValConstr()
+        {
+            return realVId;
+        }
+
+        public static Term RealVal(BigDec num)
+        {
+            Term realConst = new RealConst(num);
+            return RealVal(realConst);
+        }
+
+        public static Term RealVal(Term r)
+        {
+            return new TermApp(realVId, new List<Term> {r});
         }
 
         public static Term LookupVar(Term varContext, Term normalState, Term var)
@@ -576,6 +602,11 @@ namespace ProofGeneration
         public static Term ConvertValToInt(Term val)
         {
             return new TermApp(ConvertValToIntId, val);
+        }
+        
+        public static Term ConvertValToReal(Term val)
+        {
+            return new TermApp(ConvertValToRealId, val);
         }
 
         public static Term TypeToVal(Term absValTyMap, Term value)

--- a/Source/ProofGeneration/BoogieIsaInterface/IsaBoogieTerm.cs
+++ b/Source/ProofGeneration/BoogieIsaInterface/IsaBoogieTerm.cs
@@ -278,6 +278,9 @@ namespace ProofGeneration
                 case BinaryOperator.Opcode.Div:
                     bopIsa = "Div";
                     break;
+                case BinaryOperator.Opcode.RealDiv:
+                    bopIsa = "RealDiv";
+                    break;
                 case BinaryOperator.Opcode.Mod:
                     bopIsa = "Mod";
                     break;

--- a/Source/ProofGeneration/BoogieIsaInterface/IsaBoogieType.cs
+++ b/Source/ProofGeneration/BoogieIsaInterface/IsaBoogieType.cs
@@ -10,6 +10,7 @@ namespace ProofGeneration
         private static readonly TermIdent tprimClosedId = IsaCommonTerms.TermIdentFromName("TPrimC");
         private static readonly TermIdent tboolId = IsaCommonTerms.TermIdentFromName("TBool");
         private static readonly TermIdent tintId = IsaCommonTerms.TermIdentFromName("TInt");
+        private static readonly TermIdent trealId = IsaCommonTerms.TermIdentFromName("TReal");
         private static readonly TermIdent tvarId = IsaCommonTerms.TermIdentFromName("TVar");
         private static readonly TermIdent tconId = IsaCommonTerms.TermIdentFromName("TCon");
         private static readonly TermIdent tconClosedId = IsaCommonTerms.TermIdentFromName("TConC");
@@ -40,6 +41,11 @@ namespace ProofGeneration
         public static Term IntType()
         {
             return tintId;
+        }
+        
+        public static Term RealType()
+        {
+            return trealId;
         }
 
         public static Term TConType(string constructorName, List<Term> constructorArgs,

--- a/Source/ProofGeneration/BoogieIsaInterface/PureTyIsaTransformer.cs
+++ b/Source/ProofGeneration/BoogieIsaInterface/PureTyIsaTransformer.cs
@@ -105,6 +105,8 @@ namespace ProofGeneration.BoogieIsaInterface
                 ReturnResult(PrimitiveType.CreateBoolType());
             else if (node.IsInt)
                 ReturnResult(PrimitiveType.CreateIntType());
+            else if (node.IsReal)
+                ReturnResult(PrimitiveType.CreateRealType());
             else
                 throw new ProofGenUnexpectedStateException("unexpected pure basic type");
 

--- a/Source/ProofGeneration/BoogieIsaInterface/PureValueIsaTransformer.cs
+++ b/Source/ProofGeneration/BoogieIsaInterface/PureValueIsaTransformer.cs
@@ -49,6 +49,13 @@ namespace ProofGeneration.BoogieIsaInterface
                     ReturnResult(IsaBoogieTerm.IntVal(arg));
                 else
                     ReturnResult(IsaBoogieTerm.ConvertValToInt(arg));
+            } 
+            else if (node.IsReal)
+            {
+                if (constructVal)    
+                    ReturnResult(IsaBoogieTerm.RealVal(arg));
+                else
+                    ReturnResult(IsaBoogieTerm.ConvertValToReal(arg));
             }
             else
             {

--- a/Source/ProofGeneration/BoogieIsaInterface/TypeIsaVisitor.cs
+++ b/Source/ProofGeneration/BoogieIsaInterface/TypeIsaVisitor.cs
@@ -53,12 +53,10 @@ namespace ProofGeneration
                 ReturnResult(IsaBoogieType.PrimType(IsaBoogieType.BoolType(), usedClosedConstructors));
             else if (node.IsInt)
                 ReturnResult(IsaBoogieType.PrimType(IsaBoogieType.IntType(), usedClosedConstructors));
+            else if (node.IsReal)
+                ReturnResult(IsaBoogieType.PrimType(IsaBoogieType.RealType(), usedClosedConstructors));
             else
-            {
-                //TODO: change to actual reals once formalization has been updated
-                Console.Error.WriteLine("Representing reals as integers");
-                ReturnResult(IsaBoogieType.PrimType(IsaBoogieType.IntType(), usedClosedConstructors));
-            }
+                throw new NotImplementedException();
 
             return node;
         }

--- a/Source/ProofGeneration/ProgramToVCProof/EndToEndVCProof.cs
+++ b/Source/ProofGeneration/ProgramToVCProof/EndToEndVCProof.cs
@@ -1004,7 +1004,7 @@ namespace ProofGeneration.ProgramToVCProof
                     else
                         throw new ProofGenUnexpectedStateException("unexpected state corres kind");
 
-                    sb.AppendLine("by (fastforce dest: tint_intv tbool_boolv)");
+                    sb.AppendLine("by (fastforce dest: tint_intv tbool_boolv treal_realv)");
                 }
                 else
                 {

--- a/Source/ProofGeneration/ProgramToVCProof/EndToEndVCProof.cs
+++ b/Source/ProofGeneration/ProgramToVCProof/EndToEndVCProof.cs
@@ -429,6 +429,7 @@ namespace ProofGeneration.ProgramToVCProof
                 "  apply (erule allE[where ?x=" + IsaPrettyPrinterHelper.Inner(boogieValueParamsList.ToString()) +
                 "])?",
                 (outputType.IsBool ? "using tbool_boolv" : "") + (outputType.IsInt ? "using tint_intv" : "") +
+                (outputType.IsReal ? "using treal_realv" : "") +
                 " by auto"
             };
 
@@ -607,6 +608,14 @@ namespace ProofGeneration.ProgramToVCProof
                             new IntConst(ctorBasicAxInfo.CtorValue)));
                         lemmas.Add(basicTypeLemma(ctorBasicAxInfo.Type,
                             IsaBoogieType.PrimType(IsaBoogieType.BoolType(), true), ctorBasicAxInfo.CtorValue));
+                    } 
+                    else if (ctorBasicAxInfo.Type.IsReal)
+                    {
+                        funEquations.Add(new Tuple<IList<Term>, Term>(
+                            new List<Term> {IsaBoogieType.PrimType(IsaBoogieType.RealType(), true)},
+                            new IntConst(ctorBasicAxInfo.CtorValue)));
+                        lemmas.Add(basicTypeLemma(ctorBasicAxInfo.Type,
+                            IsaBoogieType.PrimType(IsaBoogieType.RealType(), true), ctorBasicAxInfo.CtorValue));
                     }
                     else
                     {
@@ -900,29 +909,38 @@ namespace ProofGeneration.ProgramToVCProof
                 else if (vcAx is BasicTypeCastAxiomInfo castAxiomInfo)
                 {
                     var isBool = castAxiomInfo.Type.IsBool;
-                    if (!isBool && !castAxiomInfo.Type.IsInt)
+                    var isInt = castAxiomInfo.Type.IsInt;
+                    var isReal = castAxiomInfo.Type.IsReal;
+                    
+                    if (!isBool && !isInt && !isReal)
                         throw new ProofGenUnexpectedStateException(GetType(),
-                            "only support int and bools as built-in types");
+                            "only support int, bool, and reals as built-in types");
 
                     switch (castAxiomInfo.CastKind)
                     {
                         case TypeCastKind.BoxedOfUnboxed:
                             if (isBool)
                                 sb.AppendLine(ProofUtil.Apply("rule bool_inverse_1"));
-                            else
+                            else if (isInt)
                                 sb.AppendLine(ProofUtil.Apply("rule int_inverse_1"));
+                            else
+                                sb.AppendLine(ProofUtil.Apply("rule real_inverse_1"));
                             break;
                         case TypeCastKind.UnboxedOfBoxed:
                             if (isBool)
                                 sb.AppendLine(ProofUtil.Apply("rule bool_inverse_2"));
-                            else
+                            else if (isInt)
                                 sb.AppendLine(ProofUtil.Apply("rule int_inverse_2"));
+                            else
+                                sb.AppendLine(ProofUtil.Apply("rule real_inverse_2"));
                             break;
                         case TypeCastKind.TypeOfBoxed:
                             if (isBool)
                                 sb.AppendLine(ProofUtil.Apply("rule bool_type"));
-                            else
+                            else if(isInt)
                                 sb.AppendLine(ProofUtil.Apply("rule int_type"));
+                            else
+                                sb.AppendLine(ProofUtil.Apply("rule real_type"));
                             break;
                         default:
                             throw new ArgumentOutOfRangeException();

--- a/Source/ProofGeneration/ProgramToVCProof/PureToBoogieValConverter.cs
+++ b/Source/ProofGeneration/ProgramToVCProof/PureToBoogieValConverter.cs
@@ -37,6 +37,8 @@ namespace ProofGeneration.ProgramToVCProof
                 ReturnResult(v => IsaBoogieTerm.BoolVal(v));
             else if (node.IsInt)
                 ReturnResult(v => IsaBoogieTerm.IntVal(v));
+            else if (node.IsReal)
+                ReturnResult(v => IsaBoogieTerm.RealVal(v));
             else
                 throw new NotImplementedException();
 

--- a/Source/ProofGeneration/Util/ProofGenSubsetChecker.cs
+++ b/Source/ProofGeneration/Util/ProofGenSubsetChecker.cs
@@ -49,8 +49,8 @@ namespace ProofGeneration.Util
 
         public override Type VisitBasicType(BasicType node)
         {
-            //only support integers and booleans as basic types
-            if (node.IsReal || node.isFloat || node.IsBv || node.IsString || node.IsRMode || node.IsRegEx)
+            //only support integers, booleans, and reals as basic types
+            if (node.isFloat || node.IsBv || node.IsString || node.IsRMode || node.IsRegEx)
             {
                 problematicNode = node;
                 return node;

--- a/Source/ProofGeneration/VCProofGen/ConcreteTypeDeclTranslation.cs
+++ b/Source/ProofGeneration/VCProofGen/ConcreteTypeDeclTranslation.cs
@@ -25,10 +25,15 @@ namespace ProofGeneration.VCProofGen
         {
             return IsaBoogieTerm.BoolValConstr();
         }
-
+        
         public override Term Int2U(Function func)
         {
             return IsaBoogieTerm.IntValConstr();
+        }
+        
+        public override Term Real2U(Function func)
+        {
+            return IsaBoogieTerm.RealValConstr();
         }
 
         public override Term U2Bool(Function func)
@@ -40,7 +45,12 @@ namespace ProofGeneration.VCProofGen
         {
             return IsaBoogieTerm.ConvertValToIntId;
         }
-
+        
+        public override Term U2Real(Function func)
+        {
+            return IsaBoogieTerm.ConvertValToRealId;
+        }
+        
         public override Term BoolType(Function func)
         {
             return IsaBoogieVC.PrimTypeClosed(IsaBoogieType.BoolType());

--- a/Source/ProofGeneration/VCProofGen/GenericTypeDeclTranslation.cs
+++ b/Source/ProofGeneration/VCProofGen/GenericTypeDeclTranslation.cs
@@ -44,12 +44,22 @@ namespace ProofGeneration.VCProofGen
             return IsaCommonTerms.TermIdentFromName(uniqueNamer.GetName(func, func.Name));
         }
 
+        public override Term U2Real(Function func)
+        {
+            return IsaCommonTerms.TermIdentFromName(uniqueNamer.GetName(func, func.Name));
+        }
+
         public override Term Int2U(Function func)
         {
             return IsaCommonTerms.TermIdentFromName(uniqueNamer.GetName(func, func.Name));
         }
 
         public override Term Bool2U(Function func)
+        {
+            return IsaCommonTerms.TermIdentFromName(uniqueNamer.GetName(func, func.Name));
+        }
+
+        public override Term Real2U(Function func)
         {
             return IsaCommonTerms.TermIdentFromName(uniqueNamer.GetName(func, func.Name));
         }

--- a/Source/ProofGeneration/VCProofGen/VCExprOpIsaVisitor.cs
+++ b/Source/ProofGeneration/VCProofGen/VCExprOpIsaVisitor.cs
@@ -209,7 +209,8 @@ namespace ProofGeneration.VCProofGen
 
         public Term VisitRealDivOp(VCExprNAry node, List<Term> arg)
         {
-            throw new NotImplementedException();
+            Contract.Assert(arg.Count == 2);
+            return new TermApp(IsaCommonTerms.TermIdentFromName("smt_real_div"), arg[0], arg[1]);
         }
 
         public Term VisitSelectOp(VCExprNAry node, List<Term> arg)
@@ -244,7 +245,8 @@ namespace ProofGeneration.VCProofGen
 
         public Term VisitToRealOp(VCExprNAry node, List<Term> arg)
         {
-            throw new NotImplementedException();
+            Contract.Assert(arg.Count == 1);
+            return new TermApp(IsaCommonTerms.RealOfInt, arg[0]);
         }
 
         public void setFunctionNamer(IsaUniqueNamer functionNamer)

--- a/Source/ProofGeneration/VCProofGen/VCExprToIsaTranslator.cs
+++ b/Source/ProofGeneration/VCProofGen/VCExprToIsaTranslator.cs
@@ -69,6 +69,8 @@ namespace ProofGeneration.VCProofGen
                 return new BoolConst(false);
             if (node is VCExprIntLit lit)
                 return new TermWithExplicitType(new IntConst(lit.Val), PrimitiveType.CreateIntType());
+            if (node is VCExprRealLit realLit)
+                return new TermWithExplicitType(new RealConst(realLit.Val), PrimitiveType.CreateRealType());
             throw new NotImplementedException();
         }
 

--- a/Source/ProofGeneration/VCProofGen/VCTypeDeclTranslation.cs
+++ b/Source/ProofGeneration/VCProofGen/VCTypeDeclTranslation.cs
@@ -34,6 +34,10 @@ namespace ProofGeneration.VCProofGen
             {
                 result = U2Bool(func);
             }
+            else if (name.Equals("U_2_real"))
+            {
+                result = U2Real(func);
+            }
             else if (name.Equals("int_2_U"))
             {
                 result = Int2U(func);
@@ -41,6 +45,10 @@ namespace ProofGeneration.VCProofGen
             else if (name.Equals("bool_2_U"))
             {
                 result = Bool2U(func);
+            }
+            else if (name.Equals("real_2_U"))
+            {
+                result = Real2U(func);
             }
             else if (IsTypeConstr(name, out var constrName))
             {
@@ -65,8 +73,10 @@ namespace ProofGeneration.VCProofGen
         public abstract Term BoolType(Function func);
         public abstract Term U2Int(Function func);
         public abstract Term U2Bool(Function func);
+        public abstract Term U2Real(Function func);
         public abstract Term Int2U(Function func);
         public abstract Term Bool2U(Function func);
+        public abstract Term Real2U(Function func);
         public abstract Term TypeConstructor(string constrName, Function func);
         public abstract Term TypeConstructorInverse(string constrName, int index, Function func);
 

--- a/Source/VCExpr/TypeErasure.cs
+++ b/Source/VCExpr/TypeErasure.cs
@@ -578,9 +578,9 @@ namespace Microsoft.Boogie.TypeErasure
     }
 
     public virtual void Setup() {
-      /*PROOF GEN: only support integers and booleans */
+      /*PROOF GEN: only support integers, booleans, and reals */
       GetBasicTypeRepr(Type.Int);
-      //GetBasicTypeRepr(Type.Real);
+      GetBasicTypeRepr(Type.Real);
       GetBasicTypeRepr(Type.Bool);
       //GetBasicTypeRepr(Type.RMode);
       //GetBasicTypeRepr(Type.String);
@@ -700,9 +700,9 @@ namespace Microsoft.Boogie.TypeErasure
     {
       base.Setup();
       
-      /*PROOF GEN: only support integers and booleans */
+      /*PROOF GEN: only support integers, booleans, and reals */
       GetTypeCasts(Type.Int);
-      //GetTypeCasts(Type.Real);
+      GetTypeCasts(Type.Real);
       GetTypeCasts(Type.Bool);
       //GetTypeCasts(Type.RMode);
       //GetTypeCasts(Type.String);


### PR DESCRIPTION
This PR extends the proof generation to support reals. Some parts are not yet handled: automation of typing rules involving reals is not yet done, which is currently relevant if reals appear in loop invariants.