### PR TITLE
Tree hint approach for typing tactic

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,77 @@
+name: Boogie Proof Generation CI
+
+on:
+  push:
+    branches: [ master, staging, trying ]
+  pull_request:
+    branches: [ master ]
+  workflow_dispatch:
+
+env:
+  Z3_VERSION: 4.8.8
+
+jobs:
+  build:
+    strategy:
+      matrix:
+        os: [ ubuntu-latest ]
+      fail-fast: false
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          submodules: 'true'
+
+      - name: Setup dotnet
+        uses: actions/setup-dotnet@v1
+        with:
+          dotnet-version: '6.0.x'
+
+      - name: Setup Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.10.6'
+
+      - name: Get Z3 
+        run: |
+          wget --quiet https://github.com/Z3Prover/z3/releases/download/z3-${Z3_VERSION}/z3-${Z3_VERSION}-x64-ubuntu-16.04.zip
+          unzip z3-*.zip
+          echo $(find $PWD/z3* -name bin -type d)>> $GITHUB_PATH
+
+      - name: Compile Boogie proof generation
+        run: |
+          dotnet build -c Release Source/Boogie.sln
+
+      - name: Generate external benchmark proofs
+        run: |
+          BOOGIE_EXE=$(find $PWD -type f -name "BoogieDriver") 
+          python3 etc/scripts/generate_proofs.py --inputdir ProofGenerationBenchmarks/external_benchmarks/modified --outputdir table_benchmarks_proofs --boogieproofExe $BOOGIE_EXE
+
+      - name: Get Isabelle
+        run: |
+          wget --quiet https://isabelle.in.tum.de/website-Isabelle2021-1/dist/Isabelle2021-1_linux.tar.gz
+          tar -xf Isabelle2021-1_linux.tar.gz
+          rm Isabelle2021-1_linux.tar.gz
+          mv Isabelle2021-1 isabelle_dir
+          isabelle_dir/bin/isabelle version
+          echo isabelle_dir/bin >> $GITHUB_PATH
+
+      # add Boogie language session to ROOTS and create heap image (option -b)
+      # for the session so that it does not have to rechecked every time
+      - name: Set up Isabelle Boogie language session
+        run: |
+          echo "$PWD/foundational_boogie/BoogieLang" >> isabelle_dir/ROOTS
+          isabelle_dir/bin/isabelle build -b -j4 -d $PWD/foundational_boogie/BoogieLang Boogie_Lang
+          
+      - name: Check external benchmark proofs
+        run: |
+          python3 etc/scripts/check_proofs.py --inputdir table_benchmarks_proofs --reps 1
+      
+      - name: Generate Boogie benchmark proofs
+        run: |
+          BOOGIE_EXE=$(find $PWD -type f -name "BoogieDriver") 
+          python3 etc/scripts/generate_proofs.py --inputdir ProofGenerationBenchmarks/boogie_testsuite_benchmarks --outputdir boogie_benchmarks_proofs --boogieproofExe $BOOGIE_EXE
+
+      - name: Check Boogie benchmark proofs
+        run: |
+          python3 etc/scripts/check_proofs.py --inputdir boogie_benchmarks_proofs --reps 1

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "foundational_boogie"]
+	path = foundational_boogie
+	url = https://github.com/gauravpartha/foundational_boogie

--- a/ProofGenerationBenchmarks/boogie_testsuite_benchmarks/monomorphize/monomorphize0.bpl
+++ b/ProofGenerationBenchmarks/boogie_testsuite_benchmarks/monomorphize/monomorphize0.bpl
@@ -1,3 +1,4 @@
+//:: ProofGen(IgnoreFile)
 // RUN: %boogie /monomorphize "%s" > "%t"
 // RUN: %diff "%s.expect" "%t"
 

--- a/ProofGenerationBenchmarks/boogie_testsuite_benchmarks/monomorphize/monomorphize2.bpl
+++ b/ProofGenerationBenchmarks/boogie_testsuite_benchmarks/monomorphize/monomorphize2.bpl
@@ -1,3 +1,4 @@
+//:: ProofGen(IgnoreFile)
 // RUN: %boogie -monomorphize "%s" > "%t"
 // RUN: %diff "%s.expect" "%t"
 

--- a/ProofGenerationBenchmarks/boogie_testsuite_benchmarks/secure/simple.bpl
+++ b/ProofGenerationBenchmarks/boogie_testsuite_benchmarks/secure/simple.bpl
@@ -1,3 +1,4 @@
+//:: ProofGen(IgnoreFile)
 // Z3 4.1: /trace /proverOpt:O:smt.mbqi=true /proverOpt:O:smt.relevancy=0
 function  xor(a: bool, b: bool) returns (bool)  { (!a && b) || (a && !b) }
 

--- a/ProofGenerationBenchmarks/boogie_testsuite_benchmarks/test20/issue-32.bpl
+++ b/ProofGenerationBenchmarks/boogie_testsuite_benchmarks/test20/issue-32.bpl
@@ -1,3 +1,4 @@
+//:: ProofGen(IgnoreFile)
 // RUN: %boogie "%s" > "%t"
 // RUN: %diff "%s.expect" "%t"
 function  Lit<T>(x: T) : T;

--- a/ProofGenerationBenchmarks/boogie_testsuite_benchmarks/test21/NameClash.bpl
+++ b/ProofGenerationBenchmarks/boogie_testsuite_benchmarks/test21/NameClash.bpl
@@ -1,3 +1,4 @@
+//:: ProofGen(IgnoreFile)
 // RUN: %boogie -typeEncoding:p -logPrefix:0p "%s" > "%t"
 // RUN: %diff "%s.p.expect" "%t"
 // RUN: %boogie -typeEncoding:a -logPrefix:0a "%s" > "%t"

--- a/Source/ExecutionEngine/ExecutionEngine.cs
+++ b/Source/ExecutionEngine/ExecutionEngine.cs
@@ -513,10 +513,8 @@ namespace Microsoft.Boogie
       ProofGenSubsetChecker proofGenSubsetChecker = new ProofGenSubsetChecker();
       if (!proofGenSubsetChecker.ProofGenPotentiallySupportsSubset(program, out object resultNode))
       {
-        if(!CommandLineOptions.Clo.OnlyCheckProofGenSupport)
-          Console.WriteLine("Proof generation does not support this program, because of node " + resultNode);
-        
-        Environment.Exit(0);
+        Console.WriteLine("Proof generation does not support this program, because of node " + resultNode);
+        Environment.Exit(1);
       } else if (CommandLineOptions.Clo.OnlyCheckProofGenSupport)
       {
         Console.WriteLine("Success:" + bplFileName);

--- a/Source/Isabelle/ML/MLUtil.cs
+++ b/Source/Isabelle/ML/MLUtil.cs
@@ -22,6 +22,16 @@ namespace Isabelle.ML
             return MLList(e, n => n);
         }
 
+        public static string MLSome(string val)
+        {
+          return "(SOME " + val+")";
+        }
+
+        public static string MLNone()
+        {
+          return "NONE";
+        }
+
         public static string MLList<T>(IEnumerable<T> e, Func<T, string> stringReprFun)
         {
             var sb = new StringBuilder();

--- a/Source/ProofGeneration/CfgToDag/EqualityHintGenerator.cs
+++ b/Source/ProofGeneration/CfgToDag/EqualityHintGenerator.cs
@@ -1,17 +1,21 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using Isabelle.Ast;
+using Isabelle.ML;
 using Isabelle.Util;
 using Microsoft.Boogie;
 using ProofGeneration.BoogieIsaInterface.VariableTranslation;
 using ProofGeneration.Util;
+using Type = Microsoft.Boogie.Type;
 
+#nullable enable
 namespace ProofGeneration.CfgToDag
 {
-    public class EqualityHintGenerator : ResultReadOnlyVisitor<bool>
+    public class EqualityHintGenerator : ResultReadOnlyVisitor<string?>
     {
         private readonly IVariableTranslationFactory variableFactory;
-        private List<LemmaDecl> _hintLemmas;
+        private IList<LemmaDecl> _hintLemmas;
 
         private int count;
         private IVariableTranslation<TypeVariable> tyVarTranslation;
@@ -21,17 +25,37 @@ namespace ProofGeneration.CfgToDag
             this.variableFactory = variableFactory;
         }
 
+        public override string? Translate(Absy node)
+        {
+            if (!StateIsFresh()) throw new ProofGenUnexpectedStateException(GetType());
+            Visit(node);
+
+            return !Results.TryPop(out string? result) ? null : result;
+        }
+
         protected override bool TranslatePrecondition(Absy node)
         {
             return true;
         }
 
-        public IEnumerable<LemmaDecl> GetHints(Expr e)
+        public Tuple<IEnumerable<LemmaDecl>, string> GetHints(Expr e)
         {
             _hintLemmas = new List<LemmaDecl>();
             tyVarTranslation = variableFactory.CreateTranslation().TypeVarTranslation;
             Visit(e);
-            return _hintLemmas;
+
+            if (!Results.TryPop(out string? hintMLString) || hintMLString == null)
+            {
+              hintMLString = "NoPolyHint";
+            }
+
+            return Tuple.Create<IEnumerable<LemmaDecl>, string>(_hintLemmas, hintMLString);
+        }
+
+        public override Trigger VisitTrigger(Trigger node)
+        {
+          //ignore triggers
+          return node;
         }
 
         // need to push bound type variables
@@ -58,27 +82,61 @@ namespace ProofGeneration.CfgToDag
 
         public override Expr VisitNAryExpr(NAryExpr node)
         {
+            string? curHint = null;
+            
+            
             if (node.Fun is BinaryOperator bop &&
                 (bop.Op == BinaryOperator.Opcode.Eq || bop.Op == BinaryOperator.Opcode.Neq))
             {
-                var leftTy = node.Args[0].Type;
-                var rightTy = node.Args[1].Type;
+              var leftTy = node.Args[0].Type;
+              var rightTy = node.Args[1].Type;
 
-                var /*!*/
-                    unifiable = new List<TypeVariable>();
-                unifiable.AddRange(leftTy.FreeVariables);
-                unifiable.AddRange(rightTy.FreeVariables);
-                var unifier = new Dictionary<TypeVariable /*!*/, Type /*!*/>();
-                if (leftTy.Unify(rightTy, unifiable, unifier))
-                    AddHint(unifier);
-                else
-                    throw new ProofGenUnexpectedStateException("Cannot unify types for equality");
+              var /*!*/
+                unifiable = new List<TypeVariable>();
+              unifiable.AddRange(leftTy.FreeVariables);
+              unifiable.AddRange(rightTy.FreeVariables);
+              var unifier = new Dictionary<TypeVariable /*!*/, Type /*!*/>();
+              if (leftTy.Unify(rightTy, unifiable, unifier))
+              {
+                curHint = AddHint(unifier);
+              }
+              else
+              {
+                throw new ProofGenUnexpectedStateException("Cannot unify types for equality");
+              }
             }
 
-            return base.VisitNAryExpr(node);
+            var childrenHints = new List<string>();
+            bool hintsTrivial = curHint == null;
+
+            for (int i = 0, n = node.Args.Count; i < n; i++)
+            {
+              string? childHint = Translate(cce.NonNull(node.Args[i]));
+              if (childHint == null)
+              {
+                childrenHints.Add("NoPolyHint");
+              }
+              else
+              {
+                hintsTrivial = false;
+                childrenHints.Add(childHint);
+              }
+            }
+
+            if (hintsTrivial)
+            {
+              ReturnResult(null);
+            }
+            else
+            {
+              var curHintString = curHint == null ? MLUtil.MLNone() : MLUtil.MLSome(MLUtil.IsaToMLThm(curHint));
+              ReturnResult("(PolyHintNode " + MLUtil.MLTuple(curHintString, MLUtil.MLList(childrenHints)) + ")");
+            }
+
+            return node;
         }
 
-        private void AddHint(IDictionary<TypeVariable, Type> unifier)
+        private string? AddHint(IDictionary<TypeVariable, Type> unifier)
         {
             var typeIsaVisitor = new TypeIsaVisitor(tyVarTranslation);
             IDictionary<int, Term> indexToType = new Dictionary<int, Term>();
@@ -104,12 +162,20 @@ namespace ProofGeneration.CfgToDag
                         subst.Add(IsaBoogieType.IntType());
             }
 
-            var nextHintLemma =
-                new LemmaDecl(getNextHintName(), ContextElem.CreateEmptyContext(),
-                    new TermApp(IsaCommonTerms.TermIdentFromName("hint_ty_subst"), new TermList(subst)),
-                    new Proof(new List<string> {ProofUtil.By("simp add: hint_ty_subst_def")})
-                );
-            _hintLemmas.Add(nextHintLemma);
+            if (subst.Any())
+            {
+              var nextHintLemma =
+                  new LemmaDecl(getNextHintName(), ContextElem.CreateEmptyContext(),
+                      new TermApp(IsaCommonTerms.TermIdentFromName("hint_ty_subst"), new TermList(subst)),
+                      new Proof(new List<string> {ProofUtil.By("simp add: hint_ty_subst_def")})
+                  );
+              
+              _hintLemmas.Add(nextHintLemma);
+
+              return nextHintLemma.Name;
+            }
+
+            return null; //no hints needed if substitution is empty
         }
 
         private string getNextHintName()

--- a/Source/ProofGeneration/CfgToDag/TypingTacticGenerator.cs
+++ b/Source/ProofGeneration/CfgToDag/TypingTacticGenerator.cs
@@ -31,21 +31,23 @@ namespace ProofGeneration.CfgToDag
             var funMemThms = new List<string>();
 
             foreach (var v in varCollector.usedVars)
-                try
-                {
-                    lookupTyThms.Add(programAccessor.LookupVarTyLemma(v));
-                }
-                catch
-                {
-                    //variable not found, possible if, for example, v is bound
-                }
+            {
+              try
+              {
+                lookupTyThms.Add(programAccessor.LookupVarTyLemma(v));
+              }
+              catch
+              {
+                //variable not found, possible if, for example, v is bound
+              }
+            }
 
             var usedFuncs = functionCollector.UsedFunctions(e);
             foreach (var f in usedFuncs) funMemThms.Add(programAccessor.MembershipLemma(f));
 
-            var hintLemmas = equalityHintGenerator.GetHints(e);
-
-            var hintsML = MLUtil.IsaToMLThms(hintLemmas.Select(lemma => lemma.Name));
+            var lemmasAndHints = equalityHintGenerator.GetHints(e);
+            
+            var hintsML = lemmasAndHints.Item2;
             var lookupTyML = MLUtil.IsaToMLThms(lookupTyThms);
             var funMemML = MLUtil.IsaToMLThms(funMemThms);
 
@@ -59,7 +61,7 @@ namespace ProofGeneration.CfgToDag
 
             var tactic = ProofUtil.Apply(ProofUtil.MLTactic("typing_tac " + string.Join(" ", args), 1));
 
-            return Tuple.Create(tactic, hintLemmas);
+            return Tuple.Create(tactic, lemmasAndHints.Item1);
         }
     }
 }

--- a/Source/ProofGeneration/ResultReadOnlyVisitor.cs
+++ b/Source/ProofGeneration/ResultReadOnlyVisitor.cs
@@ -18,7 +18,7 @@ namespace ProofGeneration
 
         protected abstract bool TranslatePrecondition(Absy node);
 
-        public T Translate(Absy node)
+        public virtual T Translate(Absy node)
         {
             if (!StateIsFresh()) throw new ProofGenUnexpectedStateException(GetType());
             Contract.Assert(TranslatePrecondition(node));

--- a/etc/scripts/check_proofs.py
+++ b/etc/scripts/check_proofs.py
@@ -58,6 +58,9 @@ def check_proofs(input_folder, n_reps):
         print("Succeeded: " + str(n_success))
         print("Failed: " + str(n_failure))
 
+        if n_failure > 0:
+            exit(1)
+
 def main():
     parser = argparse.ArgumentParser()
 

--- a/etc/scripts/generate_proofs.py
+++ b/etc/scripts/generate_proofs.py
@@ -1,14 +1,11 @@
 import os
 import subprocess
-from datetime import datetime
 import argparse
 
-# The following command should point to the Boogie proof generation binary 
-boogie_proofgen_bin = "boogieproof"
-
-def generate_proofs(input_dir, output_dir):
+def generate_proofs(input_dir, output_dir, boogie_proofgen_bin):
     n_success = 0
     n_failure = 0
+    n_ignored = 0
 
     # turn input directory path into an absolute path, since we are going to 
     # change the working directory
@@ -21,19 +18,28 @@ def generate_proofs(input_dir, output_dir):
         for file in files:
             if file.endswith('.bpl'):
                 boogie_file_path = os.path.join(root, file)
-            
-                # check whether Boogie can produce certificates
-                errorcode = subprocess.run([boogie_proofgen_bin, boogie_file_path],stdout=subprocess.DEVNULL)
-                if(errorcode.returncode == 0):
-                    print("Generated proofs for: " + boogie_file_path)
-                    n_success += 1
-                else:
-                    print("Could not generate proofs for: " + boogie_file_path)
-                    n_failure += 1
-                    exit()
+
+                with open(boogie_file_path) as f:
+                    first_line = f.readline().strip('\n')
+                    if(first_line != "//:: ProofGen(IgnoreFile)"):
+                        # check whether Boogie can produce certificates
+                        errorcode = subprocess.run([boogie_proofgen_bin, boogie_file_path],stdout=subprocess.DEVNULL)
+                        if(errorcode.returncode == 0):
+                            print("Generated proofs for: " + boogie_file_path)
+                            n_success += 1
+                        else:
+                            print("Could not generate proofs for: " + boogie_file_path)
+                            n_failure += 1
+                            exit(1)
+                    else:
+                        #ignore file
+                        print("Ignored :" + boogie_file_path)
+                        n_ignored += 1
+                        pass
                     
     print("Generated proofs for " + str(n_success) + " tests")
     print("Could not generate proofs for " + str(n_failure) + " tests")
+    print("Ignored " + str(n_ignored) + " tests")
 
 def main():
     parser = argparse.ArgumentParser()
@@ -49,6 +55,12 @@ def main():
         required=True
     )
 
+    parser.add_argument(
+        "-b", "--boogieproofExe",
+        help="Path to Boogie proof generation executable (must be an absolute path or a command that can be executed from any directory)",
+        default="boogieproof"
+    )
+
     args = parser.parse_args()
 
     if (not(os.path.isdir(args.inputdir))):
@@ -58,8 +70,8 @@ def main():
     if (os.path.exists(args.outputdir)):
         print("The desired path " +  args.outputdir + " for the output directory already exists")
         exit(1)
-
-    generate_proofs(args.inputdir, args.outputdir)
+    
+    generate_proofs(args.inputdir, args.outputdir, args.boogieproofExe)
 
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
Previously hints were represented by a list of theorems. Now they are represented by a tree of theorems. This is required for the new typing tactic implementation (see https://github.com/gauravpartha/foundational_boogie/pull/3).